### PR TITLE
added sequence log for asset/serializable data extension

### DIFF
--- a/SequenceLogger/SequenceLogger/AssetDataExtension.cs
+++ b/SequenceLogger/SequenceLogger/AssetDataExtension.cs
@@ -1,0 +1,41 @@
+namespace SequenceLogger {
+    using ICities;
+    using JetBrains.Annotations;
+    using SequenceLogger.Util;
+    using System.Collections.Generic;
+
+    [UsedImplicitly]
+    public class AssetDataExtension : IAssetDataExtension {
+
+        [UsedImplicitly]
+        static AssetDataExtension() {
+            Log.Info("AssetDataExtension.ctor() static");
+        }
+
+        [UsedImplicitly]
+        public AssetDataExtension() {
+            Log.Info("AssetDataExtension.ctor() instance");
+        }
+
+        [UsedImplicitly]
+        public void OnAssetLoaded(string name, object asset, Dictionary<string, byte[]> userData) {
+            Log.Info($"AssetDataExtension.OnAssetLoaded(name={name}, asset={asset}, userData={userData})");
+        }
+
+        [UsedImplicitly]
+        public void OnAssetSaved(string name, object asset, out Dictionary<string, byte[]> userData) {
+            Log.Info($"AssetDataExtension.OnAssetSaved(name={name}, asset={asset})");
+            userData = null;
+        }
+
+        [UsedImplicitly]
+        public void OnCreated(IAssetData assetData) {
+            Log.Info($"AssetDataExtension.OnCreated(assetData={assetData})");
+        }
+
+        [UsedImplicitly]
+        public void OnReleased() {
+            Log.Info($"AssetDataExtension.OnReleased()");
+        }
+    }
+}

--- a/SequenceLogger/SequenceLogger/SequenceLogger.csproj
+++ b/SequenceLogger/SequenceLogger/SequenceLogger.csproj
@@ -39,7 +39,9 @@
     <Compile Include="..\VersionInfo.cs">
       <Link>Properties\VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="AssetDataExtension.cs" />
     <Compile Include="Attributes\StorageFileAttribute.cs" />
+    <Compile Include="SerializableDataExtension.cs" />
     <Compile Include="Events\LoadingManagerEvents.cs" />
     <Compile Include="Events\PlatformServiceEvents.cs" />
     <Compile Include="Events\SceneManagerEvents.cs" />

--- a/SequenceLogger/SequenceLogger/SerializableDataExtension.cs
+++ b/SequenceLogger/SequenceLogger/SerializableDataExtension.cs
@@ -1,0 +1,38 @@
+namespace SequenceLogger {
+    using ICities;
+    using JetBrains.Annotations;
+    using SequenceLogger.Util;
+
+    [UsedImplicitly]
+    public class SerializableDataExtension : ISerializableDataExtension {
+        [UsedImplicitly]
+        static SerializableDataExtension() {
+            Log.Info("SerializableDataExtension.ctor() static");
+        }
+
+        [UsedImplicitly]
+        public SerializableDataExtension() {
+            Log.Info("SerializableDataExtension.ctor() instance");
+        }
+
+        [UsedImplicitly]
+        public void OnCreated(ISerializableData serializedData) {
+            Log.Info($"SerializableDataExtension.OnCreated({serializedData})");
+        }
+
+        [UsedImplicitly]
+        public void OnReleased() {
+            Log.Info("SerializableDataExtension.OnReleased()");
+        }
+
+        [UsedImplicitly]
+        public void OnLoadData() {
+            Log.Info("SerializableDataExtension.OnLoadData()");
+        }
+
+        [UsedImplicitly]
+        public void OnSaveData() {
+            Log.Info("SerializableDataExtension.OnSaveData()");
+        }
+    }
+}


### PR DESCRIPTION
I didn't document methods because I am still not sure what do they exactly do.

when intersection asset is loaded: loading extension, asset data extension, and serializable data extension all receive their Load event. don't know why serializable data extension ... could be a bug.